### PR TITLE
Load assembly into buffer to get around MIME type issue

### DIFF
--- a/src/content/nonstandard/raccoons.njk
+++ b/src/content/nonstandard/raccoons.njk
@@ -5,5 +5,8 @@ layout: ""
 <script src="https://cdn.jsdelivr.net/gh/golang/go@master/lib/wasm/wasm_exec.js"></script>
  <script>
 const go = new Go();
-WebAssembly.instantiateStreaming(fetch("/assets/wasm/raccoons.wasm"), go.importObject).then(result=>{go.run(result.instance);});
+const resp = await fetch("/assets/wasm/raccoons.wasm");
+const buffer = await resp.arrayBuffer();
+const obj = await WebAssembly.instantiate(buffer, go.importObject);
+go.run(obj.instance);
 </script>


### PR DESCRIPTION
Trying to use `WebAssembly.instantiateStreaming(fetch("...")).then(...` in production doesn't work because the server returns an `application/octet-stream` MIME type. 